### PR TITLE
added SPDI/HGVS to FHIR Variation translation notebook and refactored notebooks 

### DIFF
--- a/notebooks/allele_builder_demo.ipynb
+++ b/notebooks/allele_builder_demo.ipynb
@@ -23,13 +23,13 @@
    "id": "f728a305",
    "metadata": {},
    "source": [
-    "### Introducing the Utils Module: `allele_factory.py`\n",
+    "### Introducing the Builder Module: `allele_builder.py`\n",
     "\n",
-    "To streamline the creation of FHIR Allele objects, we developed the **`allele_factory.py`** module, located in the **utils directory**. This module simplifies the process by allowing users to generate **FHIR Allele** and **VRS Allele** objects with only **five key attributes**.  \n",
+    "To streamline the creation of Allele objects, we developed the **`allele_builder.py`** module, located in the **builders directory**. This module simplifies the process by allowing users to generate **FHIR Allele** and **VRS Allele** objects with only **five key attributes**.  \n",
     "\n",
-    "### Functions in `allele_factory.py`  \n",
+    "### Functions in `allele_builder.py`  \n",
     "\n",
-    "#### **`create_fhir_allele()` – Generates a FHIR Allele**  \n",
+    "#### **`build_fhir_allele()` – Generates a FHIR Allele**  \n",
     "\n",
     "This function constructs a **FHIR Allele** using the following attributes:  \n",
     "\n",
@@ -39,7 +39,7 @@
     "- `allele_state` (**str**): Literal value of the allele sequence state (e.g., ACGT)  \n",
     "- `id_value` (**str**, optional): The unique identifier for the Allele instance. If not provided, a default ID will be generated in the format 'ref-to-{context_sequence_id}'\n",
     "\n",
-    "#### **`create_vrs_allele()` – Generates a VRS Allele**  \n",
+    "#### **`build_vrs_allele()` – Generates a VRS Allele**  \n",
     "\n",
     "This function constructs a **VRS Allele** using the following attributes:  \n",
     "- `context_sequence_id` (**str**): Accession number of the reference sequence. Supported prefixes include: (\"NC_\", \"NG_\", \"NM_\", \"NR_\", \"NP_\")\n",
@@ -59,16 +59,16 @@
     "This notebook outlines a structured **workflow** to:\n",
     "\n",
     "1. **Set Up & Import Modules**  \n",
-    "   - Load the `AlleleFactory` and `VrsFhirAlleleTranslator` modules.\n",
+    "   - Load the `AlleleBuilder` and `VrsFhirAlleleTranslator` modules.\n",
     "\n",
     "2. **Generate VRS and Translate to FHIR**  \n",
-    "   - Create a **VRS Allele object** and convert it from **VRS → FHIR**.\n",
+    "   - Build a **VRS Allele object** and convert it from **VRS → FHIR**.\n",
     "\n",
     "3. **Round-Trip Translation: VRS → FHIR → VRS**  \n",
     "   - Perform a **round-trip translation** back to VRS (**VRS → FHIR → VRS**).\n",
     "   \n",
     "4. **Generate FHIR and Translate to VRS**  \n",
-    "   - Create a **FHIR Allele object** and convert it from **FHIR → VRS**.\n",
+    "   - Build a **FHIR Allele object** and convert it from **FHIR → VRS**.\n",
     "\n",
     "5. **Round-Trip Translation: FHIR → VRS → FHIR**  \n",
     "   - Perform a **round-trip translation** back to VRS (**FHIR → VRS → FHIR**)."
@@ -89,17 +89,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Importing the `AlleleFactory` class from the utils module\n",
-    "from utils.allele_factory import AlleleFactory\n",
+    "# Importing the `AlleleBuilder` class from the utils module\n",
+    "from builders.allele_builder import AlleleBuilder\n",
     "# Importing the `VrsFhirAlleleTranslator` class from the `translators` module\n",
     "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
+    "from ga4gh.vrs.dataproxy import create_dataproxy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2220cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
     "\n",
     "# Creating an instance of `AlleleFactory` to generate FHIR and VRS Allele objects\n",
-    "build_allele = AlleleFactory()\n",
-    "\n",
+    "build_allele = AlleleBuilder(dp=dp)\n",
     "# Creating an instance of `VrsFhirAlleleTranslator` to enable bidirectional translation \n",
     "# between GA4GH VRS and HL7 FHIR Allele representations\n",
-    "allele_translator= VrsFhirAlleleTranslator()"
+    "allele_translator= VrsFhirAlleleTranslator(dp=dp)"
    ]
   },
   {
@@ -112,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "5f3b7d72",
    "metadata": {},
    "outputs": [
@@ -132,14 +142,14 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Creating a GA4GH VRS Allele (Version 2.0) using the `create_vrs_allele` function\n",
-    "example_vrs_allele = build_allele.create_vrs_allele(\n",
+    "example_vrs_allele = build_allele.build_vrs_allele(\n",
     "    context_sequence_id=\"NC_000002.12\",\n",
     "    start=27453448,\n",
     "    end=27453449,\n",
@@ -153,7 +163,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "6aa1f487",
    "metadata": {},
    "outputs": [
@@ -175,15 +185,22 @@
        "     'type': 'MolecularDefinition'},\n",
        "    'coordinateInterval': {'coordinateSystem': {'system': {'coding': [{'system': 'http://loinc.org',\n",
        "         'code': 'LA30100-4',\n",
-       "         'display': '0-based interval counting'}]}},\n",
+       "         'display': '0-based interval counting'}]},\n",
+       "      'origin': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin',\n",
+       "         'code': 'sequence-start',\n",
+       "         'display': 'Sequence start'}]},\n",
+       "      'normalizationMethod': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method',\n",
+       "         'code': 'fully-justified',\n",
+       "         'display': 'Fully justified'}]}},\n",
        "     'startQuantity': {'value': 27453448.0},\n",
        "     'endQuantity': {'value': 27453449.0}}}}],\n",
        " 'representation': [{'focus': {'coding': [{'system': 'http://hl7.org/fhir/moleculardefinition-focus',\n",
-       "      'code': 'allele-state'}]},\n",
+       "      'code': 'allele-state',\n",
+       "      'display': 'Allele State'}]},\n",
        "   'literal': {'value': 'T'}}]}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -207,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "04e35fc5",
    "metadata": {},
    "outputs": [
@@ -238,7 +255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "c7e71d03",
    "metadata": {},
    "outputs": [
@@ -260,22 +277,29 @@
        "     'type': 'MolecularDefinition'},\n",
        "    'coordinateInterval': {'coordinateSystem': {'system': {'coding': [{'system': 'http://loinc.org',\n",
        "         'code': 'LA30100-4',\n",
-       "         'display': '0-based interval counting'}]}},\n",
+       "         'display': '0-based interval counting'}]},\n",
+       "      'origin': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin',\n",
+       "         'code': 'sequence-start',\n",
+       "         'display': 'Sequence start'}]},\n",
+       "      'normalizationMethod': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method',\n",
+       "         'code': 'fully-justified',\n",
+       "         'display': 'Fully justified'}]}},\n",
        "     'startQuantity': {'value': 27453448.0},\n",
        "     'endQuantity': {'value': 27453449.0}}}}],\n",
        " 'representation': [{'focus': {'coding': [{'system': 'http://hl7.org/fhir/moleculardefinition-focus',\n",
-       "      'code': 'allele-state'}]},\n",
+       "      'code': 'allele-state',\n",
+       "      'display': 'Allele State'}]},\n",
        "   'literal': {'value': 'T'}}]}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Creating an HL7 FHIR Allele using the `create_fhir_allele` function\n",
-    "example_fhir_allele = build_allele.create_fhir_allele(\n",
+    "example_fhir_allele = build_allele.build_fhir_allele(\n",
     "    context_sequence_id=\"NC_000002.12\",\n",
     "    start=27453448,\n",
     "    end=27453449,\n",
@@ -288,7 +312,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "43b76dac",
    "metadata": {},
    "outputs": [
@@ -315,7 +339,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -347,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "32c2d29c",
    "metadata": {},
    "outputs": [

--- a/notebooks/fhir_allele_translation.ipynb
+++ b/notebooks/fhir_allele_translation.ipynb
@@ -35,13 +35,23 @@
    "source": [
     "from profiles.allele import Allele as FhirAllele\n",
     "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
-    "\n",
-    "allele_translator = VrsFhirAlleleTranslator()"
+    "from ga4gh.vrs.dataproxy import create_dataproxy\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "50292391",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
+    "allele_translator = VrsFhirAlleleTranslator(dp=dp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "494320bc",
    "metadata": {},
    "outputs": [],
@@ -144,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d1e7de6e",
    "metadata": {},
    "outputs": [
@@ -177,7 +187,7 @@
        "   'literal': {'value': 'T'}}]}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -197,7 +207,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "40c71a9f",
    "metadata": {},
    "outputs": [
@@ -217,7 +227,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "af899f82",
    "metadata": {},
    "outputs": [
@@ -253,7 +263,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "06d4ffaf",
    "metadata": {},
    "outputs": [],
@@ -375,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "759ca000",
    "metadata": {},
    "outputs": [
@@ -407,7 +417,7 @@
        "   'literal': {'value': 'ATA'}}]}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -419,7 +429,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "9ce692f8",
    "metadata": {},
    "outputs": [
@@ -439,7 +449,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'ATA'}}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/fhir_variation_translation.ipynb
+++ b/notebooks/fhir_variation_translation.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9a15e59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from translators.variation_translator import VariationTranslation\n",
+    "from ga4gh.vrs.dataproxy import create_dataproxy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1285fee8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ga4gh.vrs.extras.translator import AlleleTranslator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e05ef5f4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
+    "vt = VariationTranslation(dp=dp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce695f3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hgvs_examples = {\n",
+    "    'del': \"NC_000003.12:g.10140148_10140759del\",\n",
+    "    'delins': \"NC_000006.12:g.42978032_42978578delinsTGACCA\",\n",
+    "    \"dup\": \"NC_000001.11:g.240208070_240208135dup\",\n",
+    "    \"ins\": \"NC_000002.12:g.203870707_203870773delinsA\",\n",
+    "    \"sub\":\"NC_000019.9:g.40398179G>A\",\n",
+    "    \"identity\": \"NM_198455.2:n.1115_1116=\"\n",
+    "    }\n",
+    "\n",
+    "spdi_examples = [\n",
+    "    \"NC_000001.11:115705283:CGTAGC:C\",\n",
+    "    \"NC_000001.11:150554374:CT:\"\n",
+    "    ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cdbac1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['del']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"del\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91b2fcb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['delins']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"delins\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "95ed4825",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['dup']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"dup\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c039bc67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['ins']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"ins\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9c9f3f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['sub']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"sub\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b90248f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{hgvs_examples['identity']}----------------\")\n",
+    "vt.translate_from(hgvs_examples[\"identity\"],fmt= \"hgvs\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10b7ccf9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{spdi_examples[0]}----------------\")\n",
+    "vt.translate_from(spdi_examples[0],fmt= \"spdi\").model_dump()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26eb7399",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"-------------{spdi_examples[1]}----------------\")\n",
+    "vt.translate_from(spdi_examples[1],fmt= \"spdi\").model_dump()"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/vrs_allele_translation.ipynb
+++ b/notebooks/vrs_allele_translation.ipynb
@@ -40,12 +40,20 @@
     "from ga4gh.vrs.models import SequenceLocation,SequenceReference,LiteralSequenceExpression,sequenceString,Allele\n",
     "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
     "from vrs_tools.normalizer import VariantNormalizer\n",
-    "from api.seqrepo import SeqRepoClient\n",
+    "from ga4gh.vrs.dataproxy import create_dataproxy\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "00f85aca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
     "\n",
-    "\n",
-    "allele_translator = VrsFhirAlleleTranslator()\n",
-    "seqrepo_api = SeqRepoClient()\n",
-    "norm = VariantNormalizer(dataproxy=seqrepo_api.dataproxy)\n"
+    "allele_translator = VrsFhirAlleleTranslator(dp=dp)\n",
+    "norm = VariantNormalizer(dp=dp)"
    ]
   },
   {
@@ -60,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "id": "cad6914f",
    "metadata": {},
    "outputs": [
@@ -83,7 +91,7 @@
        "  'repeatSubunitLength': 1}}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +105,7 @@
     "alt_seq = \"C\"\n",
     "\n",
     "\n",
-    "refget_accession = seqrepo_api.dataproxy.derive_refget_accession(f\"refseq:{refseq}\")\n",
+    "refget_accession = dp.derive_refget_accession(f\"refseq:{refseq}\")\n",
     "seq_ref = SequenceReference(\n",
     "    refgetAccession=refget_accession.split(\"refget:\")[-1]\n",
     "    )\n",
@@ -123,7 +131,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "d4807be5",
    "metadata": {},
    "outputs": [
@@ -152,7 +160,13 @@
        "     'type': 'MolecularDefinition'},\n",
        "    'coordinateInterval': {'coordinateSystem': {'system': {'coding': [{'system': 'http://loinc.org',\n",
        "         'code': 'LA30100-4',\n",
-       "         'display': '0-based interval counting'}]}},\n",
+       "         'display': '0-based interval counting'}]},\n",
+       "      'origin': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin',\n",
+       "         'code': 'sequence-start',\n",
+       "         'display': 'Sequence start'}]},\n",
+       "      'normalizationMethod': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method',\n",
+       "         'code': 'fully-justified',\n",
+       "         'display': 'Fully justified'}]}},\n",
        "     'startQuantity': {'value': 1014263.0},\n",
        "     'endQuantity': {'value': 1014265.0}}}}],\n",
        " 'representation': [{'focus': {'coding': [{'system': 'http://hl7.org/fhir/moleculardefinition-focus',\n",
@@ -161,7 +175,7 @@
        "   'literal': {'value': 'C'}}]}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -184,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "539792d4",
    "metadata": {},
    "outputs": [
@@ -204,7 +218,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'ATA'}}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,7 +232,7 @@
     "alt_seq = \"ATA\"\n",
     "\n",
     "\n",
-    "refget_accession = seqrepo_api.dataproxy.derive_refget_accession(f\"refseq:{refseq}\")\n",
+    "refget_accession = dp.derive_refget_accession(f\"refseq:{refseq}\")\n",
     "seq_ref = SequenceReference(\n",
     "    refgetAccession=refget_accession.split(\"refget:\")[-1]\n",
     "    )\n",
@@ -242,7 +256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "42f83950",
    "metadata": {},
    "outputs": [
@@ -271,7 +285,13 @@
        "     'type': 'MolecularDefinition'},\n",
        "    'coordinateInterval': {'coordinateSystem': {'system': {'coding': [{'system': 'http://loinc.org',\n",
        "         'code': 'LA30100-4',\n",
-       "         'display': '0-based interval counting'}]}},\n",
+       "         'display': '0-based interval counting'}]},\n",
+       "      'origin': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin',\n",
+       "         'code': 'sequence-start',\n",
+       "         'display': 'Sequence start'}]},\n",
+       "      'normalizationMethod': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method',\n",
+       "         'code': 'fully-justified',\n",
+       "         'display': 'Fully justified'}]}},\n",
        "     'startQuantity': {'value': 113901365.0},\n",
        "     'endQuantity': {'value': 113901365.0}}}}],\n",
        " 'representation': [{'focus': {'coding': [{'system': 'http://hl7.org/fhir/moleculardefinition-focus',\n",
@@ -280,7 +300,7 @@
        "   'literal': {'value': 'ATA'}}]}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,7 +323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "85b7a473",
    "metadata": {},
    "outputs": [
@@ -323,7 +343,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -337,7 +357,7 @@
     "alt_seq = \"T\"\n",
     "\n",
     "\n",
-    "refget_accession = seqrepo_api.dataproxy.derive_refget_accession(f\"refseq:{refseq}\")\n",
+    "refget_accession = dp.derive_refget_accession(f\"refseq:{refseq}\")\n",
     "seq_ref = SequenceReference(\n",
     "    refgetAccession=refget_accession.split(\"refget:\")[-1]\n",
     "    )\n",
@@ -361,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "8f4bc738",
    "metadata": {},
    "outputs": [
@@ -390,7 +410,13 @@
        "     'type': 'MolecularDefinition'},\n",
        "    'coordinateInterval': {'coordinateSystem': {'system': {'coding': [{'system': 'http://loinc.org',\n",
        "         'code': 'LA30100-4',\n",
-       "         'display': '0-based interval counting'}]}},\n",
+       "         'display': '0-based interval counting'}]},\n",
+       "      'origin': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin',\n",
+       "         'code': 'sequence-start',\n",
+       "         'display': 'Sequence start'}]},\n",
+       "      'normalizationMethod': {'coding': [{'system': 'http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method',\n",
+       "         'code': 'fully-justified',\n",
+       "         'display': 'Fully justified'}]}},\n",
        "     'startQuantity': {'value': 27453448.0},\n",
        "     'endQuantity': {'value': 27453449.0}}}}],\n",
        " 'representation': [{'focus': {'coding': [{'system': 'http://hl7.org/fhir/moleculardefinition-focus',\n",
@@ -399,7 +425,7 @@
        "   'literal': {'value': 'T'}}]}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/vrs_fhir_full_translation_demo.ipynb
+++ b/notebooks/vrs_fhir_full_translation_demo.ipynb
@@ -32,16 +32,27 @@
     "from ga4gh.vrs.models import Allele                           # VRS Allele model definition\n",
     "from translators.vrs_to_fhir import VrsToFhirAlleleTranslator # Converts VRS Alleles to FHIR Allele Profile\n",
     "from translators.fhir_to_vrs import FhirToVrsAlleleTranslator # Converts FHIR Alleles back to VRS format\n",
-    "import json\n",
-    "\n",
-    "# Instantiate utility classes\n",
-    "vrs_translator = VrsToFhirAlleleTranslator()\n",
-    "fhir_translator = FhirToVrsAlleleTranslator()\n"
+    "from ga4gh.vrs.dataproxy import create_dataproxy #Create a dataproxy to connect to seqrepo \n",
+    "import json\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "5697dcce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
+    "\n",
+    "# Instantiate utility classes\n",
+    "vrs_translator = VrsToFhirAlleleTranslator(dp=dp)\n",
+    "fhir_translator = FhirToVrsAlleleTranslator()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "c2d08623",
    "metadata": {},
    "outputs": [],
@@ -115,7 +126,7 @@
     "            \"type\": \"SequenceReference\",\n",
     "            \"residueAlphabet\": \"aa\",\n",
     "            \"moleculeType\": \"protein\",\n",
-    "            \"circular\": False,\n",
+    "            # \"circular\": False,\n",
     "            \"sequence\": \"V\",\n",
     "            \"extensions\": [\n",
     "                {\n",
@@ -184,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "e6caade0",
    "metadata": {},
    "outputs": [
@@ -236,7 +247,6 @@
        "     'description': 'sequence_reference.extension.description'}],\n",
        "   'refgetAccession': 'SQ.cQvw4UsHHRRlogxbWCB8W-mKD4AraM9y',\n",
        "   'residueAlphabet': 'aa',\n",
-       "   'circular': False,\n",
        "   'sequence': 'V',\n",
        "   'moleculeType': 'protein'},\n",
        "  'start': 599,\n",
@@ -258,7 +268,7 @@
        "  'sequence': 'E'}}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +283,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "9b8c2fc5",
    "metadata": {},
    "outputs": [
@@ -290,8 +300,9 @@
       "      \"moleculeType\": {\n",
       "        \"coding\": [\n",
       "          {\n",
-      "            \"system\": \"http://hl7.org/fhir/sequence-type\",\n",
-      "            \"code\": \"protein\"\n",
+      "            \"system\": \"https://w3id.org/ga4gh/schema/vrs/2.0.1/json/SequenceReference#properties/moleculeType\",\n",
+      "            \"code\": \"amino acid\",\n",
+      "            \"display\": \"amino acid Sequence\"\n",
       "          }\n",
       "        ]\n",
       "      },\n",
@@ -362,7 +373,8 @@
       "        \"coding\": [\n",
       "          {\n",
       "            \"system\": \"https://w3id.org/ga4gh/schema/vrs/2.0.1/json/SequenceReference#properties/moleculeType\",\n",
-      "            \"code\": \"protein\"\n",
+      "            \"code\": \"amino acid\",\n",
+      "            \"display\": \"amino acid Sequence\"\n",
       "          }\n",
       "        ]\n",
       "      },\n",
@@ -423,9 +435,9 @@
       "  \"moleculeType\": {\n",
       "    \"coding\": [\n",
       "      {\n",
-      "        \"system\": \"http://hl7.org/fhir/sequence-type\",\n",
-      "        \"code\": \"protein\",\n",
-      "        \"display\": \"protein Sequence\"\n",
+      "        \"system\": \"https://w3id.org/ga4gh/schema/vrs/2.0.1/json/SequenceReference#properties/moleculeType\",\n",
+      "        \"code\": \"amino acid\",\n",
+      "        \"display\": \"amino acid Sequence\"\n",
       "      }\n",
       "    ]\n",
       "  },\n",
@@ -498,6 +510,24 @@
       "                  \"system\": \"http://loinc.org\",\n",
       "                  \"code\": \"LA30100-4\",\n",
       "                  \"display\": \"0-based interval counting\"\n",
+      "                }\n",
+      "              ]\n",
+      "            },\n",
+      "            \"origin\": {\n",
+      "              \"coding\": [\n",
+      "                {\n",
+      "                  \"system\": \"http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/coordinate-origin\",\n",
+      "                  \"code\": \"sequence-start\",\n",
+      "                  \"display\": \"Sequence start\"\n",
+      "                }\n",
+      "              ]\n",
+      "            },\n",
+      "            \"normalizationMethod\": {\n",
+      "              \"coding\": [\n",
+      "                {\n",
+      "                  \"system\": \"http://hl7.org/fhir/uv/molecular-definition-data-types/CodeSystem/normalization-method\",\n",
+      "                  \"code\": \"fully-justified\",\n",
+      "                  \"display\": \"Fully justified\"\n",
       "                }\n",
       "              ]\n",
       "            }\n",
@@ -632,13 +662,14 @@
     "# Translate a fully populated VRS Allele object into its FHIR AlleleProfile representation\n",
     "translated_fhir_allele_profile  = vrs_translator.translate_allele_to_fhir(full_vrs_example)\n",
     "\n",
+    "\n",
     "# Serialize the FHIR AlleleProfile to a formatted JSON string for readable display\n",
     "print(json.dumps(translated_fhir_allele_profile.model_dump(), indent=2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "8adeca9d",
    "metadata": {},
    "outputs": [
@@ -690,7 +721,6 @@
        "     'description': 'sequence_reference.extension.description'}],\n",
        "   'refgetAccession': 'SQ.cQvw4UsHHRRlogxbWCB8W-mKD4AraM9y',\n",
        "   'residueAlphabet': 'aa',\n",
-       "   'circular': False,\n",
        "   'sequence': 'V',\n",
        "   'moleculeType': 'protein'},\n",
        "  'start': 599,\n",
@@ -712,7 +742,7 @@
        "  'sequence': 'E'}}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -727,7 +757,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "d8527c1e",
    "metadata": {},
    "outputs": [
@@ -737,7 +767,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This PR adds a new Jupyter notebook that demonstrates how SPDI and HGVS expressions are translated into FHIR VariationProfile resources. It also refactors existing notebooks to improve clarity and consistency.