### PR TITLE
Refactor/rename module and split classes for minimal translator

### DIFF
--- a/notebooks/01_simple_allele_creation_and_translation.ipynb
+++ b/notebooks/01_simple_allele_creation_and_translation.ipynb
@@ -92,7 +92,7 @@
     "# Importing the `AlleleBuilder` class from the utils module\n",
     "from builders.allele_builder import AlleleBuilder\n",
     "# Importing the `VrsFhirAlleleTranslator` class from the `translators` module\n",
-    "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
+    "from translators.minimal_allele_translator import MinimalFhirAlleleToVrsAlleleTranslator,MinimalVrsAlleleToFhirAlleleTranslator\n",
     "from ga4gh.vrs.dataproxy import create_dataproxy\n"
    ]
   },
@@ -109,7 +109,8 @@
     "build_allele = AlleleBuilder(dp=dp)\n",
     "# Creating an instance of `VrsFhirAlleleTranslator` to enable bidirectional translation \n",
     "# between GA4GH VRS and HL7 FHIR Allele representations\n",
-    "allele_translator= VrsFhirAlleleTranslator(dp=dp)"
+    "fhir_translator = MinimalFhirAlleleToVrsAlleleTranslator(dp=dp)\n",
+    "vrs_translator = MinimalVrsAlleleToFhirAlleleTranslator(dp=dp)"
    ]
   },
   {
@@ -208,7 +209,7 @@
    "source": [
     "# Translating a GA4GH VRS Allele into an HL7 FHIR Allele\n",
     "# This function takes a VRS Allele object and converts it into its corresponding FHIR representation\n",
-    "vrs_to_fhir_translation_example = allele_translator.translate_allele_to_fhir(example_vrs_allele)\n",
+    "vrs_to_fhir_translation_example = vrs_translator.translate(example_vrs_allele)\n",
     "\n",
     "# Converting the translated Allele object into a dictionary representation for easy viewing\n",
     "vrs_to_fhir_translation_example.model_dump()"
@@ -239,7 +240,7 @@
    ],
    "source": [
     "# Translate the FHIR Allele profile back to a VRS Allele object\n",
-    "back_to_vrs = allele_translator.translate_allele_to_vrs(vrs_to_fhir_translation_example)\n",
+    "back_to_vrs = fhir_translator.translate(vrs_to_fhir_translation_example)\n",
     "\n",
     "print(\"Check if the original and round-tripped VRS Allele are identical.\")\n",
     "print(example_vrs_allele == back_to_vrs)"
@@ -347,7 +348,7 @@
    "source": [
     "# Translating an HL7 FHIR Allele into a GA4GH VRS Allele\n",
     "# This function converts a FHIR Allele object into its corresponding VRS representation\n",
-    "fhir_to_vrs_translation_example = allele_translator.translate_allele_to_vrs(example_fhir_allele)\n",
+    "fhir_to_vrs_translation_example = fhir_translator.translate(example_fhir_allele)\n",
     "\n",
     "# Printing the type of the translated object to confirm the output class\n",
     "print(type(fhir_to_vrs_translation_example))\n",
@@ -386,7 +387,7 @@
    ],
    "source": [
     "# Translate the VRS Allele object back to FHIR Allele \n",
-    "back_to_fhir = allele_translator.translate_allele_to_fhir(fhir_to_vrs_translation_example)\n",
+    "back_to_fhir = vrs_translator.translate(fhir_to_vrs_translation_example)\n",
     "\n",
     "print(\"Check if the original and round-tripped FHIR Allele are identical.\")\n",
     "print(example_fhir_allele == back_to_fhir)"
@@ -405,7 +406,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "MolDef-VRS-Translator",
    "language": "python",
    "name": "python3"
   },
@@ -419,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/02_vrs_to_fhir_allele_translation.ipynb
+++ b/notebooks/02_vrs_to_fhir_allele_translation.ipynb
@@ -31,28 +31,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "981980c4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# importing the vrs models\n",
     "from ga4gh.vrs.models import SequenceLocation,SequenceReference,LiteralSequenceExpression,sequenceString,Allele\n",
-    "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
+    "from translators.minimal_allele_translator import MinimalVrsAlleleToFhirAlleleTranslator\n",
+    "\n",
     "from vrs_tools.normalizer import VariantNormalizer\n",
     "from ga4gh.vrs.dataproxy import create_dataproxy\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "00f85aca",
    "metadata": {},
    "outputs": [],
    "source": [
     "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
     "\n",
-    "allele_translator = VrsFhirAlleleTranslator(dp=dp)\n",
+    "vrs_translator = MinimalVrsAlleleToFhirAlleleTranslator(dp=dp)\n",
+    "\n",
     "norm = VariantNormalizer(dp=dp)"
    ]
   },
@@ -68,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "cad6914f",
    "metadata": {},
    "outputs": [
@@ -91,7 +93,7 @@
        "  'repeatSubunitLength': 1}}"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -131,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "d4807be5",
    "metadata": {},
    "outputs": [
@@ -175,14 +177,14 @@
        "   'literal': {'value': 'C'}}]}"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Translating the normalized allele into an allele profile\n",
-    "allele_profile_del_example = allele_translator.translate_allele_to_fhir(norm_del_example_1)\n",
+    "allele_profile_del_example = vrs_translator.translate(norm_del_example_1)\n",
     "\n",
     "print(type(allele_profile_del_example))\n",
     "allele_profile_del_example.model_dump()"
@@ -198,7 +200,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "539792d4",
    "metadata": {},
    "outputs": [
@@ -218,7 +220,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'ATA'}}"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -256,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "42f83950",
    "metadata": {},
    "outputs": [
@@ -300,14 +302,14 @@
        "   'literal': {'value': 'ATA'}}]}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Translating the normalized allele into an allele profile\n",
-    "allele_profile_insertion = allele_translator.translate_allele_to_fhir(norm_insertion_example)\n",
+    "allele_profile_insertion = vrs_translator.translate(norm_insertion_example)\n",
     "\n",
     "print(type(allele_profile_insertion))\n",
     "allele_profile_insertion.model_dump()"
@@ -323,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "85b7a473",
    "metadata": {},
    "outputs": [
@@ -343,7 +345,7 @@
        " 'state': {'type': 'LiteralSequenceExpression', 'sequence': 'T'}}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -381,7 +383,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "id": "8f4bc738",
    "metadata": {},
    "outputs": [
@@ -425,14 +427,14 @@
        "   'literal': {'value': 'T'}}]}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# Translating the normalized allele into an allele profile\n",
-    "allele_profile_sub_example = allele_translator.translate_allele_to_fhir(norm_sub_example)\n",
+    "allele_profile_sub_example = vrs_translator.translate(norm_sub_example)\n",
     "\n",
     "print(type(allele_profile_sub_example))\n",
     "allele_profile_sub_example.model_dump()"
@@ -453,7 +455,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "MolDef-VRS-Translator",
    "language": "python",
    "name": "python3"
   },
@@ -467,7 +469,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/03_fhir_to_vrs_allele_translation.ipynb
+++ b/notebooks/03_fhir_to_vrs_allele_translation.ipynb
@@ -34,7 +34,7 @@
    "outputs": [],
    "source": [
     "from profiles.allele import Allele as FhirAllele\n",
-    "from translators.vrs_fhir_translator import VrsFhirAlleleTranslator\n",
+    "from translators.minimal_allele_translator import MinimalFhirAlleleToVrsAlleleTranslator\n",
     "from ga4gh.vrs.dataproxy import create_dataproxy\n"
    ]
   },
@@ -46,7 +46,7 @@
    "outputs": [],
    "source": [
     "dp = create_dataproxy(uri=\"seqrepo+file:///usr/local/share/seqrepo/2024-12-20\")\n",
-    "allele_translator = VrsFhirAlleleTranslator(dp=dp)"
+    "fhir_translator = MinimalFhirAlleleToVrsAlleleTranslator(dp=dp)"
    ]
   },
   {
@@ -233,7 +233,7 @@
     }
    ],
    "source": [
-    "vrs_example_allele_substitution_norm = allele_translator.translate_allele_to_vrs(example_allele_substitution)\n",
+    "vrs_example_allele_substitution_norm = fhir_translator.translate(example_allele_substitution)\n",
     "vrs_example_allele_substitution_norm.model_dump(exclude_none=True)"
    ]
   },
@@ -269,7 +269,7 @@
     }
    ],
    "source": [
-    "vrs_example_allele_substitution_unnorm = allele_translator.translate_allele_to_vrs(example_allele_substitution,normalize=False)\n",
+    "vrs_example_allele_substitution_unnorm = fhir_translator.translate(example_allele_substitution,normalize=False)\n",
     "vrs_example_allele_substitution_unnorm.model_dump(exclude_none=True)"
    ]
   },
@@ -455,7 +455,7 @@
     }
    ],
    "source": [
-    "vrs_example_allele_insertion = allele_translator.translate_allele_to_vrs(example_allele_insertion)\n",
+    "vrs_example_allele_insertion = fhir_translator.translate(example_allele_insertion)\n",
     "vrs_example_allele_insertion.model_dump(exclude_none=True)"
    ]
   },
@@ -476,7 +476,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "venv",
+   "display_name": "MolDef-VRS-Translator",
    "language": "python",
    "name": "python3"
   },
@@ -490,7 +490,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,

--- a/src/translators/minimal_allele_translator.py
+++ b/src/translators/minimal_allele_translator.py
@@ -13,14 +13,6 @@ from ga4gh.vrs.models import (
     SequenceReference,
     sequenceString,
 )
-
-from conventions.coordinate_systems import vrs_coordinate_interval
-from conventions.refseq_identifiers import (
-    detect_sequence_type,
-    refseq_to_fhir_id,
-    translate_sequence_id,
-    validate_accession,
-)
 from profiles.allele import Allele as FhirAllele
 from profiles.sequence import Sequence as FhirSequence
 from resources.moleculardefinition import (
@@ -31,20 +23,26 @@ from resources.moleculardefinition import (
     MolecularDefinitionRepresentation,
     MolecularDefinitionRepresentationLiteral,
 )
+
+from conventions.coordinate_systems import vrs_coordinate_interval
+from conventions.refseq_identifiers import (
+    detect_sequence_type,
+    refseq_to_fhir_id,
+    translate_sequence_id,
+    validate_accession,
+)
 from translators.validations.allele import validate_allele_profile, validate_vrs_allele
 from translators.validations.indexing import apply_indexing
 from vrs_tools.normalizer import VariantNormalizer
 
+"""Provide minimal bidirectional translation between VRS Allele and FHIR Allele Profiles."""
 
-class VrsFhirAlleleTranslator:
-    """Provide minimal bidirectional translation between VRS Allele and FHIR Allele Profiles."""
-
+class MinimalFhirAlleleToVrsAlleleTranslator:
+    """Provide minimal translation from a FHIR Allele Profile to a VRS Allele object."""
     def __init__(self, dp=None, uri: str | None = None):
         self.dp = dp or create_dataproxy(uri=uri)
         self.service = VariantNormalizer(dp=self.dp)
         self.allele_denormalizer = VariantNormalizer(dp=self.dp)
-
-    ##############################################################
 
     def _is_valid_sequence_location(self, locations):
         """Validates the `sequenceLocation` structure within the provided locations to ensure all necessary attributes are present for accurate translations.
@@ -168,25 +166,6 @@ class VrsFhirAlleleTranslator:
                         "Missing `literal.value` for the `allele-state` representation."
                     )
 
-    def _extract_vrs_values(self, expression, dp):
-        """Extract GA4GH ID, RefSeq ID, start, end, and sequence from a VRS Allele.
-
-        Args:
-            expression: A VRS Allele object.
-            dp: SeqRepo data proxy for ID translation.
-
-        Returns:
-            tuple: (refseq_id, start_pos, end_pos, alt_allele)
-        """
-        validate_vrs_allele(expression)
-
-        refgetAccession = translate_sequence_id(dp, expression)
-        start_pos = expression.location.start
-        end_pos = expression.location.end
-        alt_allele = expression.state.sequence.model_dump()
-
-        return refgetAccession, start_pos, end_pos, alt_allele
-
     def _validate_and_extract_code(self, expression):
         if not expression.contained:
             raise ValueError("Missing 'contained' field.")
@@ -207,9 +186,7 @@ class VrsFhirAlleleTranslator:
 
         return validate_accession(code_item.coding[0].code)
 
-    #############################################################
-
-    def translate_allele_to_vrs(self, expression, normalize=True):
+    def translate(self, expression, normalize=True):
         """Converts an FHIR Allele Profile object into a GA4GH VRS Allele object.
 
         Args:
@@ -266,7 +243,34 @@ class VrsFhirAlleleTranslator:
 
         return self.service.normalize(allele) if normalize else allele
 
-    def translate_allele_to_fhir(self, expression):
+
+class MinimalVrsAlleleToFhirAlleleTranslator:
+    """Provide minimal translation from a FHIR Allele Profile to a VRS Allele object."""
+    def __init__(self, dp=None, uri: str | None = None):
+        self.dp = dp or create_dataproxy(uri=uri)
+        self.service = VariantNormalizer(dp=self.dp)
+        self.allele_denormalizer = VariantNormalizer(dp=self.dp)
+
+    def _extract_vrs_values(self, expression, dp):
+        """Extract GA4GH ID, RefSeq ID, start, end, and sequence from a VRS Allele.
+
+        Args:
+            expression: A VRS Allele object.
+            dp: SeqRepo data proxy for ID translation.
+
+        Returns:
+            tuple: (refseq_id, start_pos, end_pos, alt_allele)
+        """
+        validate_vrs_allele(expression)
+
+        refgetAccession = translate_sequence_id(dp, expression)
+        start_pos = expression.location.start
+        end_pos = expression.location.end
+        alt_allele = expression.state.sequence.model_dump()
+
+        return refgetAccession, start_pos, end_pos, alt_allele
+
+    def translate(self, expression):
         """Converts an GA4GH VRS Allele object into FHIR Allele object.
 
         Args:
@@ -364,3 +368,5 @@ class VrsFhirAlleleTranslator:
             location=[location],
             representation=[moldef_repr],
         )
+
+

--- a/tests/test_allele_profile_minimal_translation.py
+++ b/tests/test_allele_profile_minimal_translation.py
@@ -1,7 +1,7 @@
 import pytest
 
 from profiles.allele import Allele as FhirAllele
-from translators.vrs_fhir_translator import VrsFhirAlleleTranslator
+from translators.minimal_allele_translator import MinimalFhirAlleleToVrsAlleleTranslator
 
 
 @pytest.fixture
@@ -89,7 +89,7 @@ def example():
 
 @pytest.fixture
 def allele_translator():
-    return VrsFhirAlleleTranslator()
+    return MinimalFhirAlleleToVrsAlleleTranslator()
 
 
 @pytest.fixture
@@ -137,7 +137,7 @@ def vrs_expected_outputs():
 def test_translate_allele_profile(
     allele_translator, allele_profile, vrs_expected_outputs, normalize
 ):
-    output_dict = allele_translator.translate_allele_to_vrs(
+    output_dict = allele_translator.translate(
         allele_profile, normalize=normalize
     ).model_dump(exclude_none=True)
 

--- a/tests/test_vrs_allele_minimal_translation.py
+++ b/tests/test_vrs_allele_minimal_translation.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from ga4gh.vrs.models import Allele
 
-from translators.vrs_fhir_translator import VrsFhirAlleleTranslator
+from translators.minimal_allele_translator import MinimalVrsAlleleToFhirAlleleTranslator
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def example():
 
 @pytest.fixture
 def allele_translator():
-    return VrsFhirAlleleTranslator()
+    return MinimalVrsAlleleToFhirAlleleTranslator()
 
 
 @pytest.fixture
@@ -142,5 +142,5 @@ def alleleprofile_expected_outputs():
 def test_translate_vrs_to_alleleprofile(
     allele_translator, vrs_allele, alleleprofile_expected_outputs
 ):
-    output_dict = allele_translator.translate_allele_to_fhir(vrs_allele).model_dump()
+    output_dict = allele_translator.translate(vrs_allele).model_dump()
     assert output_dict == alleleprofile_expected_outputs


### PR DESCRIPTION
Refactored the minimal translator between VRS and FHIR to improve clarity, consistency, and separation of responsibilities.

Changes
* Renamed the module for clarity and consistency: vrs_fhir_translator.py → minimal_allele_translator.py
* Split the original VrsFhirAlleleTranslator class into two focused classes: MinimalFhirAlleleToVrsAlleleTranslator & MinimalVrsAlleleToFhirAlleleTranslator
* Standardized method names across translators to use translate
* Updated the associated notebook and pytest tests to reflect the refactor


This change is a structural refactor intended to improve maintainability; no functional changes are expected.